### PR TITLE
Remove hide-comment-action

### DIFF
--- a/.github/workflows/manifest.yaml
+++ b/.github/workflows/manifest.yaml
@@ -17,12 +17,6 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: int128/hide-comment-action@850168a162175291c7f4e75f8a223fb4d23402a2 # v1.31.0
-        with:
-          ends-with: |
-            <!-- kustomize-action -->
-            <!-- diff-action -->
-
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ github.head_ref }}


### PR DESCRIPTION
Since https://github.com/int128/diff-action/releases/tag/v1.39.0, the default comment strategy has been changed to replace. No need to hide comments.